### PR TITLE
Pin packages to remain compatible with sphinx 4.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,11 @@ sphinx-prompt==1.4.0
 sphinx-notfound-page==0.8
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.2
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 
 # Markdown
 myst_parser==0.17.2


### PR DESCRIPTION
This PR fixes quickly initial install on new machines.

We ran into [that problem](https://github.com/sphinx-doc/sphinx/issues/11890) which is basically because Sphinx doesn't pin some essential packages like `sphinxcontrib-applehelp` and others. Then version 2 of this package is installed which requires Sphinx 5.

This is a quick fix: we want to get going. Ideally we would either update to Sphinx 5 or make sure we are completely aligned with the readthedocs configuration, but we are postponing this potential problem for now.