### PR TITLE
Remove pdf format

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,6 @@ python:
 
 formats:
   - htmlzip
-  - pdf
 
 build:
   os: ubuntu-20.04


### PR DESCRIPTION
This PR removes the PDF format generation, as the generated pdf doesn't contain any figures.

~This is most likely because translation seems to imply LaTex for which SVG never worked, I think.~

In any case, the single HTML page is fixing the problem stated in #11 (having a downloadable version of the documentation).